### PR TITLE
Some improvements for theme

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,41 @@
+## Changes
+
+This is a list of changes and improvements over original [hugo-multi-bootswatch](https://github.com/mpas/hugo-multi-bootswatch) theme.
+
+### Support for lang meta in HTML
+
+Original theme uses ```<html lang='en-US'>``` and ```<body lang='en'>``` without easy way to change this. In this theme you can change this parameter by adding ```languageCode = 'your_language_code'``` in your ```[params]``` section of _config.toml_.
+
+### Nicer title for tab in your browser
+
+Instead of priting just post's title (as in original theme) I decided to print site main title after post's one.
+
+### Summary instead of Content on frontpages
+
+Because it's looking nice. Don't forget to paste ```<!--more-->``` in your content!
+
+### Avoiding Summary for short posts
+
+If you want some (probably, short) post displayed without cut on frontpages, use variable ```nocut = true``` in post's front matter.
+
+### Separate copyright string
+
+Define ```copyright = 'blah'``` in ```[params]``` section of _config.toml_.
+
+### Dynamic links on navbar
+
+After default _Home_ and _Blog_ link there will be no default _Resume_ and _About_ link. Links to all posts with `menu = 'main'` will be placed instead.
+
+# Basic localization
+
+You can define custom names of many elements inside template. This section on _config.toml_ is self-descriptive:
+
+```
+# all this is optional
+[params.strings]
+  home_navbar_link = "Home"
+  blog_navbar_link = "Blog"
+  read_more_link = "Read more"
+  posts_list_header = "Posts"
+  date_format = '02.01.2006'
+```

--- a/layouts/_default/frontpage-post.html
+++ b/layouts/_default/frontpage-post.html
@@ -3,22 +3,28 @@
 			<!-- <div class="col-md-offset-1 col-md-10"> -->
 			<div class="col-md-offset-1 col-md-10">
 				<h3><a href="{{.Permalink}}">{{ .Title }}</a></h3>
-					<span class="label label-primary">{{ .Date.Format "Mon Jan 2, 2006" }}</span> in 
+					<span class="label label-primary">{{ if .Site.Params.strings.date_format }}{{ .Date.Format .Site.Params.strings.date_format }}{{ else }}{{ .Date.Format "Mon, Jan 2, 2006" }}{{ end }}</span> in
 					{{ range $i, $e :=.Params.categories }}
 						{{if $i}} , {{end}}
 						<a href="/categories/{{ . | urlize }}">{{ . }}</a>
-					{{ end }} using tags 			 
+					{{ end }} using tags
 					{{ range $i, $e :=.Params.tags }}
 						{{if $i}} , {{end}}
 						<a href="/tags/{{ . | urlize }}">{{ . }}</a>
 					{{ end }}
 				</small>
 			</div>
-		</div>	
+		</div>
 		<div class="row">
 			<div class="col-md-offset-1 col-md-10">
-				<br> 
-				{{ .Content }}
+				<br>
+				{{ if .Params.nocut }}
+					{{ .Content }}
+				{{ else }}
+  				{{ .Summary }}
+					<br>
+					<a href="{{ .Permalink }}">{{ if .Site.Params.strings.read_more_link }}{{ .Site.Params.strings.read_more_link }}{{ else }}Read more{{ end }}</a>
+				{{ end }}
 			</div>
 		</div>
 		<div class="row">

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,7 +1,7 @@
 {{ partial "header.html" . }}
 	<div class="row">
 		<div class="text-center">
-			<h3>Posts</h3>
+			<h3>{{ if .Site.Params.strings.posts_list_header }}{{ .Site.Params.strings.posts_list_header }}{{ else }}Posts{{ end }}</h3>
 	    </div>
     </div>
 	<div class="row">

--- a/layouts/_default/post-title.html
+++ b/layouts/_default/post-title.html
@@ -3,6 +3,6 @@
 		<h4><a href="{{.Permalink}}">{{ .Title }}</a></h4>
 	</div>
 	<div class="col-md-4 col-md-4">
-		<h4>{{ .Date.Format "Mon Jan 2, 2006" }}</h4>
+		<h4>{{ if .Site.Params.strings.date_format }}{{ .Date.Format .Site.Params.strings.date_format }}{{ else }}{{ .Date.Format "Mon, Jan 2, 2006" }}{{ end }}</h4>
 	</div>
 </div>

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -1,10 +1,9 @@
 {{ partial "header.html" . }}
 
-<div class="container">	
+<div class="container">
 	<div class="row">
 		<div class="col-md-offset-1 col-md-10">
 			<h3>{{ .Title }}</h3>
-			<span class="label label-primary">{{ .Date.Format "Mon Jan 2, 2006" }}</span>
 		</div>
 	</div>
 	<div class="row">
@@ -17,7 +16,7 @@
 		<div class="col-md-12">
 			<hr>
 		</div>
-	</div>	
+	</div>
 </div>
 
 {{ partial "footer.html" . }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,7 +3,7 @@
             <footer>
                 <div class="pull-left">
                     <p>
-                        &copy; 2014 {{ .Site.Params.author }} ~ Powered By <a href="http://hugo.spf13.com">Hugo</a> - version: {{ .Hugo.Version }} ~ Copyright © 2015 <a href="{{ .Site.BaseURL }}/license">License</a>
+                        &copy; {{ .Site.Params.copyright }} ~ Powered By <a href="http://hugo.spf13.com">Hugo</a> - version: {{ .Hugo.Version }} ~
                     </p>
                 </div>
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="no-js" lang="{{ .Site.Params.languageCode }}" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
+<html class="no-js" lang="{{ if .Site.Params.languageCode }}{{ .Site.Params.languageCode }}{{ else }}en-us{{end}}" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -32,6 +32,6 @@
     <!-- rss -->
     <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
 </head>
-<body lang="{{ .Site.Params.languageCode }}">
+<body lang="{{ if .Site.Params.languageCode }}{{ .Site.Params.languageCode }}{{ else }}en{{ end }}">
     <!-- navbar -->
     {{ partial "navbar" . }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="no-js" lang="en-US" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
+<html class="no-js" lang="{{ .Site.Params.languageCode }}" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -8,9 +8,9 @@
     <meta name="author" content="{{ .Site.Params.author }}">
 
     <meta name="keyword" content="">
-    <link rel="shortcut icon" href="/img/favicon.ico">
+    <link rel="shortcut icon" href="/favicon.ico">
 
-    <title>{{ if eq .URL "/" }}{{ .Site.Title }}{{ else if eq .URL "/post/" }}All Entries &middot; {{ .Site.Title }}{{ else if in .URL "/tags/" }}Tags | {{ .Site.Title }}{{ else }}{{ .Title }}{{ end }}</title>
+    <title>{{ if eq .URL "/" }}{{ .Site.Title }}{{ else if eq .URL "/post/" }}All Entries &middot; {{ .Site.Title }}{{ else if in .URL "/tags/" }}Tags | {{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
 
    	<!-- selection of themed bootstrap css to load-->
     {{ if isset .Site.Params "theme" }}
@@ -32,6 +32,6 @@
     <!-- rss -->
     <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
 </head>
-<body lang="en">
+<body lang="{{ .Site.Params.languageCode }}">
     <!-- navbar -->
     {{ partial "navbar" . }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -6,10 +6,11 @@
             </div>
             <div class="navbar-collapse collapse navbar-responsive-collapse">
                 <ul class="nav navbar-nav navbar-right">
-                    <li><a href="{{ .Site.BaseURL }}">Home</a></li>
-                    <li><a href="{{ .Site.BaseURL }}/page/about/">About</a></li>
-                    <li><a href="{{ .Site.BaseURL }}/page/resume/">Resume</a></li>
-                    <li><a href="{{ .Site.BaseURL }}/post/">Blog</a></li>
+                    <li><a href="{{ .Site.BaseURL }}">{{ if .Site.Params.strings.home_navbar_link }}{{ .Site.Params.strings.home_navbar_link }}{{ else }}Home{{ end }}</a></li>
+                    <li><a href="{{ .Site.BaseURL }}/post/">{{ if .Site.Params.strings.blog_navbar_link }}{{ .Site.Params.strings.blog_navbar_link }}{{ else }}Blog{{ end }}</a></li>
+                    {{ range .Site.Menus.main }}
+                      <li><a href="{{.URL}}"> {{ .Name }} </a></li>
+                    {{end}}
                 </ul>
             </div>
         </div>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -1,14 +1,14 @@
 {{ partial "header.html" . }}
 
-<div class="container">	
+<div class="container">
 	<div class="row">
 		<div class="col-md-offset-1 col-md-10">
 			<h3>{{ .Title }}</h3>
-				<span class="label label-primary">{{ .Date.Format "Mon Jan 2, 2006" }}</span> in 
+				<span class="label label-primary">{{ if .Site.Params.strings.date_format }}{{ .Date.Format .Site.Params.strings.date_format }}{{ else }}{{ .Date.Format "Mon, Jan 2, 2006" }}{{ end }}</span> in 
 				{{ range $i, $e :=.Params.categories }}
 					{{if $i}} , {{end}}
 					<a href="/categories/{{ . | urlize }}">{{ . }}</a>
-				{{ end }} using tags 			 
+				{{ end }} using tags
 				{{ range $i, $e :=.Params.tags }}
 					{{if $i}} , {{end}}
 					<a href="/tags/{{ . | urlize }}">{{ . }}</a>
@@ -26,7 +26,7 @@
 		<div class="col-md-12">
 			<hr>
 		</div>
-	</div>	
+	</div>
 </div>
 
 {{ partial "footer.html" . }}


### PR DESCRIPTION
I really like your theme, thanks for your work!

Here's some improvements I've made for more awesomeness.
### Support for lang meta in HTML

Original theme uses `<html lang='en-US'>` and `<body lang='en'>` without easy way to change this. In this theme you can change this parameter by adding `languageCode = 'your_language_code'` in your `[params]` section of _config.toml_.
### Nicer title for tab in your browser

Instead of priting just post's title (as in original theme) I decided to print site main title after post's one.
### Summary instead of Content on frontpages

Because it's looking nice. Don't forget to paste `<!--more-->` in your content!
### Avoiding Summary for short posts

If you want some (probably, short) post displayed without cut on frontpages, use variable `nocut = true` in post's front matter.
### Separate copyright string

Define `copyright = 'blah'` in `[params]` section of _config.toml_.
### Dynamic links on navbar

After default _Home_ and _Blog_ link there will be no default _Resume_ and _About_ link. Links to all posts with `menu = 'main'` will be placed instead.
# Basic localization

You can define custom names of many elements inside template. This section on _config.toml_ is self-descriptive:

```
# all this is optional
[params.strings]
  home_navbar_link = "Home"
  blog_navbar_link = "Blog"
  read_more_link = "Read more"
  posts_list_header = "Posts"
  date_format = '02.01.2006'
```

(You can read CHANGES.md and destroy it after merging).
