### PR TITLE
Linklog functionality and some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ It is a simple template containing a nice header menu bar and content area. Defa
 * links (used for "linklogs", small blocks of text with link to external site)
 
 You can add posts to the main menu see [Adding posts to main menu](#adding-post-to-main-menu). For understanding, what is "linklog" see [Linklog usage](#linklog-usage)
+
 ---
 
 * [Contributors](#contributors)

--- a/README.md
+++ b/README.md
@@ -3,18 +3,19 @@ Hugo Multi Bootswatch Theme
 
 Hugo Multi BootSwatch Theme is a single column theme for [hugo](http://hugo.spf13.com/) based on [Twitter Bootstrap](http://getbootstrap.com/) and a css styling from [Bootswatch](http://bootswatch.com/).
 
-It is a simple template containing a nice header menu bar and content area. Default the theme support 1 type of content.
+It is a simple template containing a nice header menu bar and content area. Default the theme support 2 types of content.
 
 * posts (used for standard blogposts and optional be placed in the menu!)
+* links (used for "linklogs", small blocks of text with link to external site)
 
-You can add posts to the main menu see [Adding posts to main menu](#adding-post-to-main-menu)
-
+You can add posts to the main menu see [Adding posts to main menu](#adding-post-to-main-menu). For understanding, what is "linklog" see [Linklog usage](#linklog-usage)
 ---
 
 * [Contributors](#contributors)
 * [Installation](#installation)
 * [Usage](#usage)
 * [Adding posts to main menu](#adding-post-to-main-menu)
+* [Linklog usage](#linklog-usage)
 * [Configuration](#configuration)
 * [Built-in colour themes](#colour-themes)
 * [Screenshots](#screenshots)
@@ -42,7 +43,7 @@ You can add posts to the main menu see [Adding posts to main menu](#adding-post-
 ---
 
 ## Contributors
-* [Valdos Sine](http://brainstorage.me/fat0troll)
+* [Valdos Sine](http://blog.toofat.ru)
 * [Marco Pas](http://mpas.github.io)
 
 ---
@@ -87,6 +88,11 @@ paginate    = 10                    # the number of posts on a page
     # The format shown here is the same one Jekyll/Octopress uses by default.
     post = "/blog/:year/:month/:day/:title/"
 
+[author]
+    # Optional. Used in RSS feed meta information.
+    name = "your name"
+    email = "example <at> example <dot> com"
+
 [params]
     # language code for your website
     languagecode = "en-US"
@@ -118,7 +124,7 @@ paginate    = 10                    # the number of posts on a page
 
     # name of the header used in the post list page
     posts_list_header = "Posts"
-    
+
     # used date format
     date_format = '02.01.2006'
 
@@ -147,17 +153,43 @@ paginate    = 10                    # the number of posts on a page
 ```
 
 ## Colour themes
-All the available color themes from [Bootswatch](http://bootswatch.com/) are available. Please checkout Bootswatch to see what theme you want to use. 
+All the available color themes from [Bootswatch](http://bootswatch.com/) are available. Please checkout Bootswatch to see what theme you want to use.
 
 ## Adding post to main menu
 If you want to add a post to the main menu then include the following to the frontmatter:
-  
+
     +++
     ...
     menu = "main"
     +++
 
 The `menu = main` will add the post to the menu. These posts will not be included in the listing of normal posts or in the frontpage!!
+
+## Linklog usage
+
+Some people using their blogs as place for sharing links and storing their own opinion on them. In this theme you have separate content type named "link" for this. Every link produces small block of text on your front page (and in RSS feed too) with your comment on it.
+
+For creating new link in your linklog, invoke
+
+```
+hugo new link/example.md
+```
+
+It will create template with frontmatter like this:
+
+```
++++
+draft = true
+title = "Title of the external link"
+author = "Author of the external content"
+ref = "http://example.com/"
+type = "link"
++++
+
+Content of your comment on external link goes here.
+```
+
+where `title` is a title of your comment on link, `author` is the author of original content you refer to, `ref` is a link to the content, and `type` indicates that this is linklog content. 
 
 ## Screenshots
 ### Index Page

--- a/archetypes/link.md
+++ b/archetypes/link.md
@@ -1,0 +1,9 @@
++++
+draft = true
+title = "Title of the external link"
+author = "Author of the external content"
+ref = "http://example.com/"
+type = "link"
++++
+
+Content of your comment on external link goes here.

--- a/layouts/_default/frontpage-post.html
+++ b/layouts/_default/frontpage-post.html
@@ -4,12 +4,12 @@
 				<!-- <div class="col-md-offset-1 col-md-10"> -->
 				<div class="col-md-offset-1 col-md-10">
 					<h3><a href="{{.Permalink}}">{{ .Title }}</a></h3>
-						<span class="label label-primary">
+						<small><span class="label label-primary">
 							{{ if .Site.Params.strings.date_format }}
 								{{ .Date.Format .Site.Params.strings.date_format }}
 							{{ else }}
 								{{ .Date.Format "Mon, Jan 2, 2006" }}
-							{{ end }}</span>&nbsp;in 
+							{{ end }}</span>&nbsp;in
 							{{ range $i, $e :=.Params.categories }}
 								{{if $i}} , {{end}}
 								<a href="/categories/{{ . | urlize }}">{{ . }}</a>

--- a/layouts/_default/frontpage-post.html
+++ b/layouts/_default/frontpage-post.html
@@ -48,4 +48,33 @@
 				</div>
 			</div>
 		{{ end }}
+	{{ else if eq .Type "link" }}
+		<div class="row">
+			<div class="col-md-offset-1 col-md-10">
+				<small>
+					<span class="label label-primary">
+						{{ if .Site.Params.strings.date_format }}
+							{{ .Date.Format .Site.Params.strings.date_format }}
+						{{ else }}
+							{{ .Date.Format "Mon, Jan 2, 2006" }}
+						{{ end }}
+					</span>
+					&nbsp;<b>
+						{{ if .Site.Params.strings.linklog_text }}
+							{{ .Site.Params.strings.linklog_text }}
+						{{ else }}
+							Linklog:
+						{{ end }}
+					</b>&nbsp;{{ .Params.author }}: <a href="{{ .Permalink }}">{{ .Title }}</a>
+				</small>
+				<small>
+					{{ .Content }}
+				</small>
+				</div>
+				<div class="row">
+					<div class="col-md-12">
+						<hr>
+					</div>
+				</div>
+		</div>
 	{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,7 @@
 {{ partial "header.html" . }}
 
     <div class="container">
-        {{ $paginator := .Paginate (where .Data.Pages "Section" "post") }}
+        {{ $paginator := .Paginate (where .Data.Pages "Section" "in" "post link") }}
         {{ range $paginator.Pages }}
             {{ .Render "frontpage-post" }}
         {{ end }}
@@ -21,5 +21,3 @@
         </div>
     </div>
 {{ partial "footer.html" . }}
-
-

--- a/layouts/link/single.html
+++ b/layouts/link/single.html
@@ -1,0 +1,7 @@
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url={{ .Params.ref }}" />
+  </head>
+  <body>
+  </body>
+</html>

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -1,0 +1,27 @@
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ with .Title }}in {{.}} {{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
+    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    <atom:link href="{{.URL}}" rel="self" type="application/rss+xml" />
+    {{ range first 15 .Data.Pages }}
+      {{ if eq .Type "post"}}
+        {{ if ne .Params.menu "main" }}
+          <item>
+            <title>{{ .Title }}</title>
+            <link>{{ .Permalink }}</link>
+            <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+            {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+            <guid>{{ .Permalink }}</guid>
+            <description>{{ .Content | html }}</description>
+          </item>
+        {{ end }}
+    {{ end }}
+  </channel>
+</rss>

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -22,6 +22,16 @@
             <description>{{ .Content | html }}</description>
           </item>
         {{ end }}
+      {{ else if eq .Type "link" }}
+        <item>
+          <title>{{ if .Site.Params.strings.linklog_text }}{{ .Site.Params.strings.linklog_text }}{{ else }}Linklog: {{ end }}{{ .Title }}</title>
+          <link>{{ .Permalink }}</link>
+          <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+          <author>{{ .Params.author }}</author>
+          <guid>{{ .Permalink }}</guid>
+          <description>{{ .Content | html }}</description>
+        </item>
+      {{ end }}
     {{ end }}
   </channel>
 </rss>


### PR DESCRIPTION
Linklog is a blog when owner shares links to external sites with his own small comments. 

This is how it looks (in my own blog). Notice small block between two posts — it's a linklog item.

![2015-11-04 01 16 38](https://cloud.githubusercontent.com/assets/371254/10923650/379854fc-8293-11e5-8521-0385bba64732.png)

Also, I've added RSS feed template, so from now RSS from blog will be same as front page (without menu posts).

In addition, I fixed a typo in your frontpage-post.html (`<small>` tag).

This pull have backwards compatibility. Old users will not have any troubles.
