### PR TITLE
Only display the RSS icon if there is an RSS feed available

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -33,8 +33,10 @@
                         <a href="{{ .Site.Params.flickr }}" target="_blank">
                         <i class="fa fa-flickr fa-2x"></i></a>
                     {{ end }}
+                    {{ if .RSSlink }}
                         <a href="{{ .RSSlink }}" target="_blank">
                         <i class="fa fa-rss-square fa-2x"></i></a>
+                    {{ end }}
                 </div>
             </footer>
         </div>


### PR DESCRIPTION
There are certain conditions under which RSS feeds are not generated in Hugo. In these cases, this reference points to "nothing", which is a confusing UX.
