### PR TITLE
Linkedin href typo

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -10,7 +10,7 @@
                 <!-- social icons -->
                 <div class="pull-right">
                     {{ if isset .Site.Params "linkedin" }}
-                        <a href="{{ .Site.Params.linked }}" target="_blank">
+                        <a href="{{ .Site.Params.linkedin }}" target="_blank">
                         <i class="fa fa-linkedin fa-2x"></i></a>
                     {{ end }}
                     {{ if isset .Site.Params "facebook" }}


### PR DESCRIPTION
The linkedin parameter was referenced incorrectly causing the href
not to be populated with the 'linkedin' value from the configuration
file.
