### PR TITLE
Rename RSSlink to RSSLink

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -33,8 +33,8 @@
                         <a href="{{ .Site.Params.flickr }}" target="_blank">
                         <i class="fa fa-flickr fa-2x"></i></a>
                     {{ end }}
-                    {{ if .RSSlink }}
-                        <a href="{{ .RSSlink }}" target="_blank">
+                    {{ if .RSSLink }}
+                        <a href="{{ .RSSLink }}" target="_blank">
                         <i class="fa fa-rss-square fa-2x"></i></a>
                     {{ end }}
                 </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -30,7 +30,7 @@
     <script src="{{ .Site.BaseURL }}/js/bootstrap.min-3.3.5.js"></script>
 
     <!-- rss -->
-    <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+    <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
 </head>
 <body lang="{{ if .Site.Params.languageCode }}{{ .Site.Params.languageCode }}{{ else }}en{{ end }}">
     <!-- navbar -->


### PR DESCRIPTION
The former will be deprecated and eventually removed from Hugo.

Note: Currently both of them exist in Hugo, which is the reason for the cleanup.