### PR TITLE
fix instructions for license file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,7 @@ This theme expects a relatively standard Hugo blog/personal site layout:
     ├── post
     |   ├── post1.md
     |   └── post2.md
-    └── page
-        ├── license.md      // this is used in the footer link
+    └── license.md      // this is used in the footer link
 ```
 
 Just run `hugo --theme=hugo-multi-bootswatch` to generate your site!


### PR DESCRIPTION
The license file link goes to root/license, not root/page/license,
so adjust the instructions in the readme accordingly.
Fixes #6.