### PR TITLE
add sr-only text to footer links for accessibility

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -11,34 +11,42 @@
                 <div class="pull-right">
                     {{ if isset .Site.Params "linkedin" }}
                         <a href="{{ .Site.Params.linkedin }}" target="_blank">
+                        <span class="sr-only">LinkedIn profile</span>
                         <i class="fab fa-linkedin fa-2x"></i></a>
                     {{ end }}
                     {{ if isset .Site.Params "facebook" }}
                         <a href="{{ .Site.Params.facebook }}" target="_blank">
+                        <span class="sr-only">facebook profile</span>
                         <i class="fab fa-facebook-square fa-2x"></i></a>
                     {{ end }}
                     {{ if isset .Site.Params "twitter" }}
                         <a href="{{ .Site.Params.twitter }}" target="_blank">
+                        <span class="sr-only">twitter profile</span>
                         <i class="fab fa-twitter-square fa-2x"></i></a>
                     {{ end }}
                     {{ if isset .Site.Params "github" }}
                         <a href="{{ .Site.Params.github }}" target="_blank">
+                        <span class="sr-only">GitHub profile</span>
                         <i class="fab fa-github-square fa-2x"></i></a>
                     {{ end }}
                     {{ if isset .Site.Params "delicious" }}
                         <a href="{{ .Site.Params.delicious }}" target="_blank">
+                        <span class="sr-only">delicious profile</span>
                         <i class="fab fa-delicious fa-2x"></i></a>
                     {{ end }}
                     {{ if isset .Site.Params "flickr" }}
                         <a href="{{ .Site.Params.flickr }}" target="_blank">
+                        <span class="sr-only">flickr profile</span>
                         <i class="fab fa-flickr fa-2x"></i></a>
                     {{ end }}
                     {{ if isset .Site.Params "goodreads" }}
                         <a href="{{ .Site.Params.goodreads }}" target="_blank">
+                        <span class="sr-only">goodreads profile</span>
                         <i class="fab fa-goodreads fa-2x"></i></a>
                     {{ end }}
                     {{ if .RSSLink }}
                         <a href="{{ .RSSLink }}" target="_blank">
+                        <span class="sr-only">RSS feed</span>
                         <i class="fas fa-rss-square fa-2x"></i></a>
                     {{ end }}
                 </div>


### PR DESCRIPTION
Screenreaders need some text in order to announce where links lead.
The `sr-only` css class is already present in this theme and makes the text
invisible for seeing users.