### PR TITLE
update theme for hugo version 0.57

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,7 @@
 {{ partial "header.html" . }}
 
     <div class="container">
-        {{ $paginator := .Paginate (where .Data.Pages "Section" "in" "post link") }}
+        {{ $paginator := .Paginate (where .Site.RegularPages "Type" "in" .Site.Params.mainSections) }}
         {{ range $paginator.Pages }}
             {{ .Render "frontpage-post" }}
         {{ end }}

--- a/theme.toml
+++ b/theme.toml
@@ -3,7 +3,7 @@ license = "MIT"
 licenselink = "http://sm.mit-license.org/"
 description = "Hugo BootSwatch Theme is a single column theme for [hugo](http://hugo.spf13.com/) based on [Twitter Bootstrap](http://getbootstrap.com/) and a css styling from [Bootswatch](http://bootswatch.com/)."
 tags = ["post", "category"]
-min_version = 0.14
+min_version = 0.57.0
 
 [author]
     name = "Marco Pas"


### PR DESCRIPTION
Update paginator to work with hugo version >= 0.57 according to https://github.com/gohugoio/hugoThemes/issues/682